### PR TITLE
Add openapi/ layout for published API spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,17 @@ Please check the [releases] page.
 ### Quick links
 * [API documentation] 
 * [Developer portal]
+* [OpenAPI spec](openapi/) — YAML for client generation
 * [Cursor Agent Skills](.cursor/skills/README.md) — skills for AI-assisted API integration
 * [Agents.md](Agents.md) — agent integration guide
 * [Backstage blog]
 * [API announcements]
+
+## Repository layout
+
+| Path | Contents |
+|------|----------|
+| [`openapi/`](openapi/) | OpenAPI 3 spec (`api.yaml`), updated on each API release |
 
 ## Opening an issue
 Please use the [issue tracker] in this repository for bug reports, feature requests, suggestions, and documentation improvements. We will triage the request and mark it as one of the following types:
@@ -42,7 +49,7 @@ If you registered an app with Soundcloud and now cannot find it, it's possible y
 Contact our Support Team for further questions. Please fill out a ticket [here] under "I need help with something else" and they will get back to you as soon as they can.
 
 ### I have a questions about the SDKs. Can I post them here?
-Yes, you may. However, please note that we're not maintaining the Ruby, Python or JS SDK anymore and we're going to be announcing soon that we're going to open it for maintainers from the community if there's interest. Our recommendation is to use the API directly and build your own client. We will also be exposing the underlying yaml file for the OpenAPI spec soon, so that folks can generate clients from this. 
+Yes, you may. However, please note that we're not maintaining the Ruby, Python or JS SDK anymore and we're going to be announcing soon that we're going to open it for maintainers from the community if there's interest. Our recommendation is to use the API directly and build your own client. The OpenAPI spec is available in [`openapi/api.yaml`](openapi/api.yaml) — see [`openapi/README.md`](openapi/README.md) for download instructions. 
 
 ### I am an official partner of SoundCloud. Can I use this issue tracker for a technical question?
 This repository only deals with the public-facing API. Any partnership-specific questions don’t belong here as this is a public forum; please contact your SoundCloud partnership contact.

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,0 +1,25 @@
+# OpenAPI specification
+
+Single-file [OpenAPI 3](https://swagger.io/specification/) spec for the SoundCloud public API (`https://api.soundcloud.com`).
+
+Updated on each [release](https://github.com/soundcloud/api/releases) when the API changes.
+
+## Download
+
+Latest from `master`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/soundcloud/api/master/openapi/api.yaml -o soundcloud-api.yaml
+```
+
+Or pin to a [release tag](https://github.com/soundcloud/api/releases):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/soundcloud/api/2026-05-19/openapi/api.yaml -o soundcloud-api.yaml
+```
+
+## Generate a client
+
+Use [OpenAPI Generator](https://openapi-generator.tech/) or any OpenAPI-aware tool with the downloaded spec.
+
+Interactive reference: [developers.soundcloud.com/docs/api/reference](https://developers.soundcloud.com/docs/api/reference)


### PR DESCRIPTION
## Summary
- Adds `openapi/` with README and placeholder for `api.yaml` (published from api-public on each release)
- Updates main README with quick link, layout section, and FAQ pointing to the OpenAPI spec

## Test plan
- [ ] Review README links and layout section
- [ ] Merge before first automated publish from api-public