### PR TITLE
Document API credentials CLI and scripts/

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please don't post security issues or vulnerabilities here. Refer to [Security.md
 
 ## Frequently asked questions
 ### Can I request an API key for a new app?
-You can register for an API key by going to your profile [you/apps](https://www.soundcloud.com/you/apps), or use the [API credentials CLI](https://github.com/soundcloud/api-public-auth-cli) (`scripts/sc-api-auth.mjs`):
+You can register for an API key by going to your profile [you/apps](https://www.soundcloud.com/you/apps), or use the [API credentials CLI](https://github.com/soundcloud/api-public-auth-cli) ([`scripts/sc-api-auth.mjs`](scripts/sc-api-auth.mjs)):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/soundcloud/api/master/scripts/sc-api-auth.mjs -o sc-api-auth.mjs

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Please check the [releases] page.
 * [API documentation] 
 * [Developer portal]
 * [OpenAPI spec](openapi/) — YAML for client generation
+* [API credentials CLI](https://github.com/soundcloud/api-public-auth-cli) — obtain a `client_id` from the command line
 * [Cursor Agent Skills](.cursor/skills/README.md) — skills for AI-assisted API integration
 * [Agents.md](Agents.md) — agent integration guide
 * [Backstage blog]
@@ -19,6 +20,7 @@ Please check the [releases] page.
 
 | Path | Contents |
 |------|----------|
+| [`scripts/`](scripts/) | CLI scripts (e.g. [`sc-api-auth.mjs`](scripts/sc-api-auth.mjs)) |
 | [`openapi/`](openapi/) | OpenAPI 3 spec (`api.yaml`), updated on each API release |
 
 ## Opening an issue
@@ -38,7 +40,13 @@ Please don't post security issues or vulnerabilities here. Refer to [Security.md
 
 ## Frequently asked questions
 ### Can I request an API key for a new app?
-You can register for an API key by going to your profile [you/apps](https://www.soundcloud.com/you/apps)
+You can register for an API key by going to your profile [you/apps](https://www.soundcloud.com/you/apps), or use the [API credentials CLI](https://github.com/soundcloud/api-public-auth-cli) (`scripts/sc-api-auth.mjs`):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/soundcloud/api/master/scripts/sc-api-auth.mjs -o sc-api-auth.mjs
+node sc-api-auth.mjs --name "My App" --description "…" --website "https://example.com"
+```
+
 Please also subscribe to our `@SoundCloudDev` on [X](https://x.com/SoundCloudDev) or [Bluesky](https://bsky.app/profile/soundcloud.dev) or our [Backstage Blog] for API Announcements
 
 ### How can I update my app's `redirect_uri`?

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -2,7 +2,7 @@
 
 Single-file [OpenAPI 3](https://swagger.io/specification/) spec for the SoundCloud public API (`https://api.soundcloud.com`).
 
-Updated on each [api-public release](https://github.com/soundcloud/api/releases).
+Updated on each [release](https://github.com/soundcloud/api/releases) when the API changes.
 
 ## Download
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 ## sc-api-auth.mjs
 
-Obtain a `client_id` for your API application via OAuth sign-in and app registration.
+Obtain a `client_id` for your API application via OAuth sign-in and app registration (requires Node.js 18+).
 
 Download the latest:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,13 @@
+# Scripts
+
+## sc-api-auth.mjs
+
+Obtain a `client_id` for your API application via OAuth sign-in and app registration.
+
+Download the latest:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/soundcloud/api/master/scripts/sc-api-auth.mjs -o sc-api-auth.mjs
+```
+
+Usage, options, and troubleshooting: [api-public-auth-cli](https://github.com/soundcloud/api-public-auth-cli).


### PR DESCRIPTION
## Summary
- Adds `scripts/` to the repository layout and quick links
- Adds a minimal `scripts/README.md` (download + pointer to [api-public-auth-cli](https://github.com/soundcloud/api-public-auth-cli) for usage docs)
- Updates the API key FAQ with the `sc-api-auth.mjs` curl example
- Minor wording fix in `openapi/README.md`

Follow-up to #552 and the first script publish via api-public-auth-cli.

## Test plan
- [ ] Links resolve correctly
- [ ] FAQ curl example matches published script path


Made with [Cursor](https://cursor.com)