### PR TITLE
Document --remote flag for headless CLI sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ curl -fsSL https://raw.githubusercontent.com/soundcloud/api/master/scripts/sc-ap
 node sc-api-auth.mjs --name "My App" --description "…" --website "https://example.com"
 ```
 
+Add **`--remote`** for SSH, CI, or headless sign-in (pairing code instead of a local browser callback).
+
 Please also subscribe to our `@SoundCloudDev` on [X](https://x.com/SoundCloudDev) or [Bluesky](https://bsky.app/profile/soundcloud.dev) or our [Backstage Blog] for API Announcements
 
 ### How can I update my app's `redirect_uri`?

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,12 +2,15 @@
 
 ## sc-api-auth.mjs
 
-Obtain a `client_id` for your API application via OAuth sign-in and app registration (requires Node.js 18+).
+Obtain `client_id` and `client_secret` for your API application via OAuth sign-in and app registration (requires Node.js 18+).
 
 Download the latest:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/soundcloud/api/master/scripts/sc-api-auth.mjs -o sc-api-auth.mjs
+node sc-api-auth.mjs --name "My App" --description "…" --website "https://example.com"
 ```
+
+Add **`--remote`** for SSH, CI, or headless environments (pairing-code sign-in instead of a local browser callback).
 
 Usage, options, and troubleshooting: [api-public-auth-cli](https://github.com/soundcloud/api-public-auth-cli).


### PR DESCRIPTION
## Summary
- Mention `--remote` in `scripts/README.md` and the FAQ for SSH/CI/headless sign-in.

## Test plan
- [ ] Docs read correctly on GitHub


Made with [Cursor](https://cursor.com)